### PR TITLE
Memory constraints on postgres

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -38,6 +38,9 @@ services:
         constraints:
           - node.role == worker
           - node.labels.type == datastore
+      resources:
+        limits:
+          memory: 200M
     environment:
       POSTGRES_PASSWORD_FILE: /run/secrets/database-password
       POSTGRES_USER_FILE: /run/secrets/database-user


### PR DESCRIPTION
Allocates only `200M` of memory to the Postgres container, i.e. no more than 20 simultaneous connections can be made